### PR TITLE
System-agnostic script for building the IDE and its dependendies.

### DIFF
--- a/build-full-ide.sh
+++ b/build-full-ide.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Warning: This script has been tested wit Mac OSX only.
 
@@ -430,11 +430,11 @@ function checkout_git_repo()
   if [[ "$REFS" = "tags" ]]
   then
     debug "In $FOLDER_DIR, checking out tag $BRANCH"
-    $GIT checkout $BRANCH
+    $GIT checkout -q $BRANCH
   else
     FULL_BRANCH_NAME=origin/$BRANCH
     debug "In $FOLDER_DIR, checking out branch $FULL_BRANCH_NAME"
-    $GIT checkout $FULL_BRANCH_NAME
+    $GIT checkout -q $FULL_BRANCH_NAME
   fi
   cd $BASE_DIR
   validate ${FOLDER_DIR}


### PR DESCRIPTION
This "slightly" :) modified script works quite nicely for me, let me know what you think. 
- Check executables are available.
- Clone repositories in current folder.
- Keystore password not shown in the terminal.
- Allow to select the original repositories or the scala-ide forks
  for building scala-refactoring and scalariform.
- Allow to select the branch (or tag) to be built for scala-ide, scalariform,
  and scala-refactoring.
- Allow to skip tests when building scala-refactoring. You need to
  set REFACTORING_MAVEN_ARGS=-Dmaven.test.skip=true when launching
  the script.
- Added support for SCALA_VERSION 2.11.0-SNAPSHOT
