### PR TITLE
Issue/add 2.10.x support

### DIFF
--- a/config/validator.conf
+++ b/config/validator.conf
@@ -36,8 +36,8 @@ BUILD_TYPE=validator
 
 ##### Scala information #####
 #SCALA_GIT_REPO=git://github.com/scala/scala
-# The version of Scala to use
-SCALA_VERSION=2.11.0
+# The version of Scala to use needs to be passed as an argument
+SCALA_VERSION=
 # The git version of Scala to use
 SCALA_GIT_HASH=
 

--- a/uber-build.sh
+++ b/uber-build.sh
@@ -360,13 +360,15 @@ function printErrorUsageAndExit () {
 function stepCheckArguments () {
   printStep "Check arguments"
 
-  if [ $# -gt 2 ]
+  if [ $# -gt 3 ]
   then
     printErrorUsageAndExit "Wrong arguments"
   fi
 
   CONFIG_FILE="$1"
   ARG_GIT_HASH=$2
+  ARG_SCALA_VERSION=$3
+
   if [ ! -f "${CONFIG_FILE}" ]
   then
     printErrorUsageAndExit "'${CONFIG_FILE}' doesn't exists or is not a file"
@@ -396,6 +398,12 @@ function stepLoadConfig () {
   if [ -n "${ARG_GIT_HASH}" ]
   then
     SCALA_GIT_HASH="${ARG_GIT_HASH}"
+  fi
+
+# override the Scala version with the one given as argument, if available
+  if [ -n "${ARG_SCALA_VERSION}" ]
+  then
+    SCALA_VERSION="${ARG_SCALA_VERSION}"
   fi
 
 }


### PR DESCRIPTION
The PR validation script needs a way to tell the base Scala version (2.10 vs. 2.11), for PRs that target 2.10.x. This adds support for overriding the one in the configuration file.
