### PR TITLE
Remove the build-toolchain step, which is not needed anymore.

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -910,6 +910,8 @@ function stepScalaIDE () {
 
   cd "${SCALA_IDE_DIR}"
 
+  SCALA_IDE_UID=$(git rev-parse HEAD)
+
   if $SIGN_ARTIFACTS
   then
     SCALA_IDE_P2_ID=scala-ide/${SCALA_IDE_UID}-S/${SCALA_UID}/${SBT_UID}/${SCALA_REFACTORING_UID}/${SCALARIFORM_UID}


### PR DESCRIPTION
# Please do NOT merge

This is in preparation for the switch to PSOb and needs to be synchronized with upstream projects.
