### PR TITLE
Adds git fetch for tags

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -318,6 +318,7 @@ function fetchGitBranch () {
       git remote add ${REMOTE_ID} $2
     fi
     info "Fetching update for $2"
+    git fetch --tag ${REMOTE_ID}
     git fetch ${REMOTE_ID}
   fi
 


### PR DESCRIPTION
The simple `git fetch` doesn't import the tags from the remote,
the additionnal `git fetch --tag` is needed.
