### PR TITLE
Updates P2_ID for scalariform and scala refactoring

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -886,7 +886,7 @@ function stepScalaRefactoring () {
 
   SCALA_REFACTORING_UID=$(git rev-parse HEAD)
 
-  SCALA_REFACTORING_P2_ID=scala-refactoring/${SCALA_REFACTORING_UID}/${SCALA_IDE_UID}/${SCALA_UID}
+  SCALA_REFACTORING_P2_ID=scala-refactoring/${SCALA_REFACTORING_UID}/${SCALA_UID}
 
   checkCache ${SCALA_REFACTORING_P2_ID}
   if [ $RES != 0 ]
@@ -917,7 +917,7 @@ function stepScalariform () {
 
   SCALARIFORM_UID=$(git rev-parse HEAD)
 
-  SCALARIFORM_P2_ID=scalariform/${SCALARIFORM_UID}/${SCALA_IDE_UID}/${SCALA_UID}
+  SCALARIFORM_P2_ID=scalariform/${SCALARIFORM_UID}/${SCALA_UID}
 
   checkCache ${SCALARIFORM_P2_ID}
   if [ $RES != 0 ]


### PR DESCRIPTION
Since the Scala OSGi bundles are used through all projects, there
is no need anymore to add the Scala IDE UID to the scalariform and scala
refactoring P2_ID.

P2_ID are used as ids for the cache system. They contain all dependencies of a project, to make sure to not use a cached build if something has changed.
I'm not quite sure how good it was working right now, as the Scala IDE UID
was not defined at this point.
