### PR TITLE
Make sure that Scala UID is always a git hash

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -759,10 +759,14 @@ function stepScala () {
 
   if ${SCALA_REBUILD}
   then
-    FULL_SCALA_VERSION="${SCALA_VERSION}-${SCALA_GIT_HASH}-SNAPSHOT"
-    SCALA_VERSION_SUFFIX="-$SCALA_GIT_HASH-SNAPSHOT"
+    fetchGitBranch "${SCALA_DIR}" "${SCALA_GIT_REPO}" "${SCALA_GIT_HASH}" NaN "pr"
 
-    SCALA_P2_ID=scala/${SCALA_GIT_HASH}
+    SCALA_UID=$(git rev-parse HEAD)
+
+    FULL_SCALA_VERSION="${SCALA_VERSION}-${SCALA_UID}-SNAPSHOT"
+    SCALA_VERSION_SUFFIX="-${SCALA_UID}-SNAPSHOT"
+
+    SCALA_P2_ID=scala/${SCALA_UID}
 
     checkAvailability "org.scala-lang" "scala-compiler" "${FULL_SCALA_VERSION}"
     if [ $RES = 0 ]
@@ -778,8 +782,6 @@ function stepScala () {
       fi
     else
       info "Building Scala from source"
-
-      fetchGitBranch "${SCALA_DIR}" "${SCALA_GIT_REPO}" "${SCALA_GIT_HASH}" NaN "pr"
 
       cd "${SCALA_DIR}"
 


### PR DESCRIPTION
The value of `SCALA_GIT_HASH` doesn't have to be a hash. It can be
a branch or a tag too.
Makes sure that we are using a hash as `UID`.
