### PR TITLE
Tweaks on git support and checkAvailability

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -299,10 +299,11 @@ function osgiVersion () {
 # $4 - depth (TODO: really needed?)
 # $5 - extra fetch (optional)
 function fetchGitBranch () {
-  if [ ! -d "$1" ]
+  if [ ! -d "$1/.git" ]
   then
     info "Cloning git repo $2"
     REMOTE_ID="remote01"
+    rm -rf "$1"
     git clone -o ${REMOTE_ID} "$2" "$1"
     cd "$1"
   else


### PR DESCRIPTION
- Hides the output of the mvn run for `checkAvailability`. It can be misleading when real errors occur later on.
- Check if the folders for the local copies of the project repositories actually contain a git repository. For some reason, they are getting corrupted on the scala PR validation machines.

@adriaanm, this should help for scala-pr-validation.
