### PR TITLE
correct parameter susbtitution for cache forcing

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -220,7 +220,7 @@ function checkCache () {
 # $2 - directory to cache
 # $3 - force cache usage ("true"|"false", optional)
 function storeCache () {
-  FORCE_CACHE="${2:-false}"
+  FORCE_CACHE="${3:-false}"
   if ${FORCE_CACHE} || ${WITH_CACHE}
   then
     mkdir -p "$(dirname "${P2_CACHE_DIR}/$1")"


### PR DESCRIPTION
Cf. flowdock error reported by @dragos:
    ./uber-build.sh: line 224: org.scala.tools.eclipse.search.update-site/target/site: is a directory
