### PR TITLE
Corretly force the use of the cache for Scala data

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -821,7 +821,7 @@ function stepScala () {
         mkdir tmp
         cp ${SCALA_DIR}/buildcharacter.properties tmp/versions.properties
         storeCache ${SCALA_P2_ID} tmp "true"
-        SCALA_VERSIONS_PROPERTIES_PATH=$(getCacheLocation ${SCALA_P2_ID})/versions.properties
+        SCALA_VERSIONS_PROPERTIES_PATH=$(getCacheLocation ${SCALA_P2_ID} "true")/versions.properties
       fi
 
     fi


### PR DESCRIPTION
The problem was discovered by @dotta.

When having the cache disabled, and compiling the Scala from source, the build would failed with a message about a missing `link` folder.
The code was missing the extra parameter used to force the usage of the cache while building scala.
#30 should be rebase on this.
