### PR TITLE
Add nightly build configuration for 3.0.x based on 2.11.

### DIFF
--- a/config/nightly-3.0.x-juno-2.11.conf
+++ b/config/nightly-3.0.x-juno-2.11.conf
@@ -1,0 +1,83 @@
+##### Defined in the script #####
+# CURRENT_DIR: execution dir
+#####
+
+##### local dirs #####
+# Unlikely to need modification
+#BUILD_DIR=${CURRENT_DIR}/target
+#LOCAL_M2_REPO=${BUILD_DIR}/m2repo
+#P2_CACHE_DIR=${BUILD_DIR}/p2cache
+#KEYSTORE_DIR=${BUILD_DIR}/keystore
+#SCALA_DIR=${BUILD_DIR}/scala
+#ZINC_BUILD_DIR=${BUILD_DIR}/zinc
+#SCALA_IDE_DIR=${BUILD_DIR}/scala-ide
+#SCALA_REFACTORING_DIR=${BUILD_DIR}/scala-refactoring
+#SCALARIFORM_DIR=${BUILD_DIR}/scalariform
+#WORKSHEET_PLUGIN_DIR=${BUILD_DIR}/worksheet
+#PLAY_PLUGIN_DIR=${BUILD_DIR}/play
+#SEARCH_PLUGIN_DIR=${BUILD_DIR}/search
+#PRODUCT_DIR=${BUILD_DIR}/product
+
+##### what to do #####
+# operation to perform (release, release-dryrun, nightly, scala-pr-validator, scala-pr-rebuild)
+OPERATION=nightly
+# logging type (console, file)
+LOGGING=console
+# with caching? (true or false)
+WITH_CACHE=true
+# plugins to build: "worksheet play search" (between double quotes, space separated)
+PLUGINS="worksheet search"
+# build the product (true or false)
+PRODUCT=false
+# Eclipse version (indigo, juno)
+ECLIPSE_PLATFORM=juno
+# type of build (dev, stable)
+BUILD_TYPE=dev
+
+##### Scala information #####
+SCALA_GIT_REPO=git://github.com/scala/scala
+# The version of Scala to use
+SCALA_VERSION=2.11.0-SNAPSHOT
+# The git version of Scala to use
+#SCALA_GIT_HASH=
+
+##### zinc information #####
+#ZINC_BUILD_GIT_REPO=git://github.com/typesafehub/sbt-builds-for-ide
+#ZINC_BUILD_GIT_BRANCH=master
+SBT_VERSION=0.13.0
+ZINC_BUILD_VERSION_SUFFIX=-SNAPSHOT
+
+##### Scala IDE information #####
+SCALA_IDE_GIT_REPO=git://github.com/scala-ide/scala-ide
+SCALA_IDE_GIT_BRANCH=release/scala-ide-3.0.x-juno-2.11
+SCALA_IDE_VERSION_TAG=nightly
+
+##### Scala Refactoring information #####
+#SCALA_REFACTORING_GIT_REPO=git://github.com/scala-ide/scala-refactoring
+#SCALA_REFACTORING_GIT_BRANCH=0.6.0_SI-3.0.1-RC2_2.10.2
+SCALA_REFACTORING_GIT_BRANCH=master
+
+##### Scalariform information #####
+SCALARIFORM_GIT_REPO=git://github.com/scala-ide/scalariform.git
+#SCALARIFORM_GIT_BRANCH=scala-ide-3.0.1
+SCALARIFORM_GIT_BRANCH=master
+
+##### Scala Worksheet plugin information #####
+WORKSHEET_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-worksheet.git
+WORKSHEET_PLUGIN_GIT_BRANCH=release/3.0.x-2.11
+WORKSHEET_PLUGIN_VERSION_TAG=nightly
+
+##### Play plugin information #####
+#PLAY_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-ide-play2.git
+PLAY_PLUGIN_GIT_BRANCH=master
+PLAY_PLUGIN_VERSION_TAG=nightly
+
+##### Scala Search plugin information #####
+SEARCH_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-search.git
+SEARCH_PLUGIN_GIT_BRANCH=release/3.0.x-2.11
+SEARCH_PLUGIN_VERSION_TAG=nightly
+
+##### Scala IDE product information #####
+#PRODUCT_GIT_REPO=git://github.com/typesafehub/scala-ide-product.git
+PRODUCT_GIT_BRANCH=master
+PRODUCT_VERSION_TAG=3.0.x-nightly


### PR DESCRIPTION
- does not build play (no 2.11 version of Play yet)
- does not build product (it needs Play)
