### PR TITLE
Makes Scala IDE uid more precise

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -980,7 +980,7 @@ function stepScalaIDE () {
 
   cd "${SCALA_IDE_DIR}"
 
-  SCALA_IDE_UID=$(git rev-parse HEAD)
+  SCALA_IDE_UID="$(git rev-parse HEAD)${SCALA_IDE_VERSION_TAG}"
 
   if $SIGN_ARTIFACTS
   then


### PR DESCRIPTION
Adds the Scala IDE version tag to the computed uid. To avoid the case
when Scala IDE is not rebuilt because all the bits to compile are the
same, but the full version string should be differente (like from last -rc to
-vfinal)
