### PR TITLE
Creates a config for Scala 2.10 pr-validation

### DIFF
--- a/config/validator-2.10.conf
+++ b/config/validator-2.10.conf
@@ -1,0 +1,80 @@
+##### Defined in the script #####
+# CURRENT_DIR: execution dir
+#####
+
+##### local dirs #####
+# Unlikely to need modification
+#BUILD_DIR=${CURRENT_DIR}/target
+#LOCAL_M2_REPO=${BUILD_DIR}/m2repo
+#P2_CACHE_DIR=${BUILD_DIR}/p2cache
+#KEYSTORE_DIR=${BUILD_DIR}/keystore
+#SCALA_DIR=${BUILD_DIR}/scala
+#ZINC_BUILD_DIR=${BUILD_DIR}/zinc
+#SCALA_IDE_DIR=${BUILD_DIR}/scala-ide
+#SCALA_REFACTORING_DIR=${BUILD_DIR}/scala-refactoring
+#SCALARIFORM_DIR=${BUILD_DIR}/scalariform
+#WORKSHEET_PLUGIN_DIR=${BUILD_DIR}/worksheet
+#PLAY_PLUGIN_DIR=${BUILD_DIR}/play
+#SEARCH_PLUGIN_DIR=${BUILD_DIR}/search
+#PRODUCT_DIR=${BUILD_DIR}/product
+
+##### what to do #####
+# operation to perform (release, release-dryrun, nightly, scala-pr-validator, scala-pr-rebuild)
+OPERATION=scala-pr-validator
+# logging type (console, file)
+LOGGING=console
+# with caching? (true or false)
+WITH_CACHE=false
+# plugins to build: "worksheet play search" (between double quotes, space separated)
+PLUGINS=""
+# build the product (true or false)
+PRODUCT=false
+# Eclipse version (indigo, juno, kepler)
+ECLIPSE_PLATFORM=kepler
+# type of build (dev, stable)
+BUILD_TYPE=validator
+
+##### Scala information #####
+#SCALA_GIT_REPO=git://github.com/scala/scala
+# The version of Scala to use needs to be passed as an argument
+SCALA_VERSION=
+SCALA210_VERSION=2.10.4
+# The git version of Scala to use
+SCALA_GIT_HASH=
+
+##### zinc/sbt information #####
+SBT_VERSION=0.13.2
+SBT_TAG=sbt-0.13.2-on-scala-2.11
+
+##### Scala IDE information #####
+#SCALA_IDE_GIT_REPO=git://github.com/scala-ide/scala-ide
+SCALA_IDE_GIT_BRANCH=4.0.0-m2
+SCALA_IDE_VERSION_TAG=local
+
+##### Scala Refactoring information #####
+#SCALA_REFACTORING_GIT_REPO=git://github.com/scala-ide/scala-refactoring
+SCALA_REFACTORING_GIT_BRANCH=master
+
+##### Scalariform information #####
+SCALARIFORM_GIT_REPO=git://github.com/scala-ide/scalariform.git
+SCALARIFORM_GIT_BRANCH=master
+
+##### Scala Worksheet plugin information #####
+#WORKSHEET_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-worksheet.git
+#WORKSHEET_PLUGIN_GIT_BRANCH=
+#WORKSHEET_PLUGIN_VERSION_TAG=
+
+##### Play plugin information #####
+#PLAY_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-ide-play2.git
+#PLAY_PLUGIN_GIT_BRANCH=
+#PLAY_PLUGIN_VERSION_TAG=
+
+##### Scala Search plugin information #####
+#SEARCH_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-search.git
+#SEARCH_PLUGIN_GIT_BRANCH=
+#SEARCH_PLUGIN_VERSION_TAG=
+
+##### Scala IDE product information #####
+#PRODUCT_GIT_REPO=git://github.com/typesafehub/scala-ide-product.git
+#PRODUCT_GIT_BRANCH=
+#PRODUCT_VERSION_TAG=


### PR DESCRIPTION
Current master doesn't compile on 2.10 anymore. Use the 4.0.0-m2 tag of scala-ide/scala-ide.

cc @gkossakowski
