### PR TITLE
scala pr validation publishes sbt, saves 50 min on retry

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -571,6 +571,7 @@ function stepSetFlags () {
       SCALA_VALIDATOR=true
       SCALA_REBUILD=false
       IDE_BUILD=true
+      SBT_PUBLISH=true # save time on second run
       ;;
     scala-pr-rebuild )
       SCALA_VALIDATOR=true


### PR DESCRIPTION
Because of flakiness in the test suite, we often have to retry the job,
which takes 50 minutes more than it should (that's how long it takes
to build sbt, which never fails, and thus the retry could reuse earlier
published result).