### PR TITLE
Publish sbt during PR validation

### DIFF
--- a/uber-build.sh
+++ b/uber-build.sh
@@ -571,6 +571,7 @@ function stepSetFlags () {
       SCALA_VALIDATOR=true
       SCALA_REBUILD=false
       IDE_BUILD=true
+      SBT_PUBLISH=true
       ;;
     scala-pr-rebuild )
       SCALA_VALIDATOR=true
@@ -1069,7 +1070,7 @@ EOF
 function stepZinc () {
   printStep "Zinc"
 
-  IDE_M2_REPO="https://proxy-ch.typesafe.com:8082/artifactory/ide-${SHORT_SCALA_VERSION}"
+  IDE_M2_REPO=${IDE_M2_REPO-"https://proxy-ch.typesafe.com:8082/artifactory/ide-${SHORT_SCALA_VERSION}"}
 
   if ${RELEASE}
   then


### PR DESCRIPTION
Validated by https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/841/consoleFull:
```
[sbt-republish] --== End Building sbt-republish ==--
[info] --== Deploying Artifacts  ==--
[info] Processing: https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/
[info] Deploying: sbt-republish
[info] Retrieved from project sbt-republish (commit: bc6157829bcb69943dbd479c94f6abdb56033fe6): 15 artifacts
[info] Deploying: com/typesafe/sbt/compiler-interface-precompiled/0.13.6-on-2.11.7-b697280-SNAPSHOT-for-IDE-SNAPSHOT/compiler-interface-precompiled-0.13.6-on-2.11.7-b697280-SNAPSHOT-for-IDE-SNAPSHOT.jar
```
Published to https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/com/typesafe/sbt/compiler-interface-precompiled//0.13.6-on-2.11.7-b697280-SNAPSHOT-for-IDE-SNAPSHOT/

See also https://github.com/adriaanm/scala/commit/b69728002b267d51cbdf8ab8e6a45032101f6ff9