### PR TITLE
Update Scala PR validator config

### DIFF
--- a/config/validator.conf
+++ b/config/validator.conf
@@ -35,46 +35,18 @@ ECLIPSE_PLATFORM=luna
 BUILD_TYPE=validator
 
 ##### Scala information #####
-#SCALA_GIT_REPO=git://github.com/scala/scala
 # The version of Scala to use needs to be passed as an argument
 SCALA_VERSION=
 SCALA210_VERSION=2.10.5
 # The git version of Scala to use
 SCALA_GIT_HASH=
 
-##### zinc/sbt information #####
-SBT_VERSION=0.13.6
-SBT_TAG=v0.13.6
-
 ##### Scala IDE information #####
-#SCALA_IDE_GIT_REPO=git://github.com/scala-ide/scala-ide
 SCALA_IDE_GIT_BRANCH=master
 SCALA_IDE_VERSION_TAG=local
 
 ##### Scala Refactoring information #####
-#SCALA_REFACTORING_GIT_REPO=git://github.com/scala-ide/scala-refactoring
 SCALA_REFACTORING_GIT_BRANCH=master
 
 ##### Scalariform information #####
-SCALARIFORM_GIT_REPO=git://github.com/scala-ide/scalariform.git
 SCALARIFORM_GIT_BRANCH=master
-
-##### Scala Worksheet plugin information #####
-#WORKSHEET_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-worksheet.git
-#WORKSHEET_PLUGIN_GIT_BRANCH=
-#WORKSHEET_PLUGIN_VERSION_TAG=
-
-##### Play plugin information #####
-#PLAY_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-ide-play2.git
-#PLAY_PLUGIN_GIT_BRANCH=
-#PLAY_PLUGIN_VERSION_TAG=
-
-##### Scala Search plugin information #####
-#SEARCH_PLUGIN_GIT_REPO=git://github.com/scala-ide/scala-search.git
-#SEARCH_PLUGIN_GIT_BRANCH=
-#SEARCH_PLUGIN_VERSION_TAG=
-
-##### Scala IDE product information #####
-#PRODUCT_GIT_REPO=git://github.com/typesafehub/scala-ide-product.git
-#PRODUCT_GIT_BRANCH=
-#PRODUCT_VERSION_TAG=


### PR DESCRIPTION
We no longer hardcode the sbt version, otherwise it needs to be updated
every time the sbt version is updated in scala-ide.